### PR TITLE
Ngr/relecture omop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Thumbs.db
 /build
 /node_modules
 package-lock.json
+/input/resources/structuremap-validation/local

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ Dans le script gradle se trouve de nombreuses tâches dont les plus importantes 
 * reBuildIG : supprime les répertoires créés lors d'une construction puis lance la construction. Il n'est pas nécessaire de faire appel à cette tâche systèmatiquement (cf. la description de la tâche buildIG). Cette tâche très utile lors d'un changement de version de l'IG Publisher.
 * sushiBuild : lance seuelement l'outil sushi (partique dans un contexte de cycle court de définition de fichiers FSH).
 
+### Validation des structureMap
+
+Suivre la documentation dans le dosier input\resources\structuremap-validation. 
+
+#### Prérequis 
+- instance matchbox correctement parametrer
+- module client REST dans votre IDE
+
 ## Acronymes
 
 * IG : Implementation Guide

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 nodeVersion = 18.20.3
 sushiVersion = 3.11.0
-publisherVersion = 1.6.19
+publisherVersion = 1.6.20
 tx = tx.fhir.org

--- a/input/fml/StructureMap-Death.fml
+++ b/input/fml/StructureMap-Death.fml
@@ -8,5 +8,12 @@ uses "https://interop.esante.gouv.fr/ig/fhir/eds/StructureDefinition/EDSPatient"
 uses "https://interop.esante.gouv.fr/ig/fhir/eds/StructureDefinition/OMOPDeath" alias DeathTable as target
 
 group Death(source src: Patient, target tgt: DeathTable) {
-	src.deceased as srcDeceased where src.deceased.is(System.DateTime) -> tgt.death_datetime = srcDeceased;
+  src.deceased : dateTime as srcDeceased then {
+    srcDeceased -> tgt.death_datetime = srcDeceased "setDeathDT";
+    srcDeceased -> tgt.death_date = 
+    // cast(srcDeceased, 'Date')
+    // (%srcDeceased.toDate())    
+    (%srcDeceased.toString().substring(0, 10))
+    "setDeathD";
+  } "SetDeathDate";
 }

--- a/input/fml/StructureMap-Location.fml
+++ b/input/fml/StructureMap-Location.fml
@@ -20,3 +20,16 @@ group Location(source src: Patient, target tgt : LocationTable) {
 		} "setGeolocation";
 	};
 }
+
+group MultiLocation(source src, target tgt : LocationTable) {
+	src.line first as srcLine1 -> tgt.address_1 = srcLine1 "setLineOne";
+	src.line not_first as srcLine2 -> tgt.address_2 = srcLine2 "setLineTwo";
+	src.city as srcCity -> tgt.city = srcCity "setCity";
+	src.postalCode as srcZip -> tgt.zip = srcZip "setZip";
+	src.country as srcCountry -> tgt.country_source_value = srcCountry "setCountry";
+	src.text as srcText -> tgt.location_source_value = truncate(srcText, 50) "setVerbatim";
+	src.extension as geolocation where (url = 'http://hl7.org/fhir/StructureDefinition/geolocation') then {
+		geolocation.extension as latitude where (url = 'latitude') -> tgt.latitude = (%latitude.value) "setLatitude";
+		geolocation.extension as longitude where (url = 'longitude') -> tgt.longitude = (%longitude.value) "setLongitude";
+	} "setGeolocation";
+}

--- a/input/fml/StructureMap-Patient.fml
+++ b/input/fml/StructureMap-Patient.fml
@@ -15,16 +15,16 @@ imports "https://interop.esante.gouv.fr/ig/fhir/eds/StructureMap/Location"
 imports "https://interop.esante.gouv.fr/ig/fhir/eds/StructureMap/Death"
 
 group Patient(source src: Patient, target tgtBundle : LogicalBundle) {
-  src -> tgtBundle.id = uuid() "setId";
-  src -> tgtBundle.type = 'transaction' "setType";
+	src -> tgtBundle.id = uuid() "setId";
+	src -> tgtBundle.type = 'transaction' "setType";
 	src -> tgtBundle.entry as newEntry then {
 		src -> newEntry.person = create("PersonTable") as newPerson then {
 			src then Person(src, newPerson) "transformPerson";
 		} "createPerson";
 	} "newEntryPerson";
-	src where address.empty().not() -> tgtBundle.entry as newEntry then {
-		src -> newEntry.location = create("LocationTable") as newLocation then {
-			src then Location(src, newLocation) "transformLocation";
+	src.address as srcAddress where use = 'home' and period.end.empty() -> tgtBundle.entry as newEntry then {
+		srcAddress -> newEntry.location = create("LocationTable") as newLocation then {
+			srcAddress then MultiLocation(srcAddress, newLocation) "transformLocation";
 		} "createLocation";
 	} "newEntryLocation";
 	src where deceased.is(System.DateTime) or deceased.is(System.Boolean) -> tgtBundle.entry as newEntry then {

--- a/input/resources/structuremap-validation/test_fml.http.example
+++ b/input/resources/structuremap-validation/test_fml.http.example
@@ -1,0 +1,43 @@
+# Ce fichier constitue un template pour tester les structuremap. Pour s'en servir, il faut :
+# - dupliquer ce fichier dans le dossier /input/resources/structuremap-validation/local (inclus dans le .gitignore). Vous pouvez également mettre dans ce dossier des ressources de test qui n'auraient pas d'intéret pour les autres utilisateurs. 
+# - Installer un client REST, par exemple [RESTClient (identifiant: humao.rest-client)](https://marketplace.visualstudio.com/items?itemName=humao.rest-client#:~:text=Once%20you%20prepared%20a%20request,press%20F1%20and%20then%20select%2F), cela permet d'envoyer des requêtes HTTP et d'avoir la réponse directement dans Visual Studio Code.
+# - paramétrer un serveur FHIR (l11-12)
+# - tester son bon fonctionnement et son parametrage (CapabilityStatement.implementation.description.value doit être à "Development mode") via l'exécution de la requête "I Verification serveur"
+# - paramétrer le chemin de la map que vous voullez tester (l25-26) 
+# - créer/mettre à jour la map en cours de rédaction sur le serveur fhir via l'exécution de la requête "II Creation/Mise à jour de la map"
+# - paramétrer la map à utiliser (l29-30 - mettre l'id de la map à tester, (a priori celle créée précédement)) et le chemin de la ressource à transformer (l35-36)
+# - exécuter la map sur la ressource via l'exécution de la requête "III Exécution de la map" et valider que l'output correspond à l'attendu. 
+
+# Host example:
+@host = http://localhost:8080/matchboxv3/fhir
+
+### I Verification serveur : returns metadata configuration for server, verify that you have in implementation description "Development Mode" 
+GET {{host}}/metadata HTTP/1.1
+Accept: application/fhir+json;fhirVersion=4.0
+Origin: http://localhost
+
+
+### II Creation/Mise à jour de la map : create the resource on the server
+POST {{host}}/StructureMap HTTP/1.1
+Accept: application/fhir+json
+Content-Type: text/fhir-mapping
+
+# Path example:  
+< ../../fml/usages/pediatrie/croissance-pediatrique/StructureMap-CroisPediaPhysical2Business.fml
+
+### III Exécution de la map : transform the provided questionnaire response to patient resource with using mapUrl structuremap
+# map id example
+@mapID = CroisPediaBusiness2FHIRv2
+POST {{host}}/StructureMap/$transform?source=https://aphp.fr/ig/fhir/eds/StructureMap/{{mapID}}
+Accept: application/fhir+json
+Content-Type: application/fhir+json
+
+# Path example:  
+< questionnaireResponse-CroisPediaBusiness2FHIRv2.json
+
+
+
+
+### Verify created Questionnaire
+GET {{host}}/Questionnaire/qrpatientsex
+Accept: application/fhir+json;fhirVersion=4.0


### PR DESCRIPTION
Relecture de la map patient et de ses dépendances : 
 - Death : prise en charge de death_date (comme le cast toDate n’est pas implémenté, j’ai fait un truc un peu moche)
 - Person : 
   - Vu la convention themis sur les locations: « The location_id […] should represent […] the person’s home address, or where they live the majority of the time », on peut sans doute faire quelque chose avec les ‘use’. J’ai limité à : "use = home" and "period.end.empty()", mais on pourrait prioriser ‘home’>’work ‘>’temp’ et on exclu ‘billing’ et ‘old’ et gérer plus finement les dates. 
   - Dans tous les cas comme on peut avoir plusieurs address, j'ai renvoyé à un autre group de la map location
- Location : 
   - prise en charge des pays 
   - modification de la règle pour les address.line multiple : Pas idéal puisque ça prend la première et la derniere. J'aurais préféré que ça reprenne les deux première mais j'ai pas réussi à utiliser les index...
   - gestion des adresses multiples


Je me demandais : 
- s'il ne fallais pas essayer de gérer les death_type_concept_id (et plus largement pour le projet) ? Ce champ OMOP sert à préciser le type de source, dans le cas de death on a au moins : 
  - les morts constatés à l'hopital (source EHR)
  - les morts récupérée de l'insee avec algo de réconciliation (source NLP ou Death certificate)
- si ce ne serait pas judicieux d'avoir un repo APHP plutôt que chacun son repos sur ce sujet ?